### PR TITLE
Add libicu and libssl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV PKHAX_PORT=9000
 ENV PKHAX_PRIVATE_KEY_PATH=/app/private.key
 EXPOSE 9000
 
+RUN apt-get -y update && apt-get install -y libicu-dev libssl-dev
+
 COPY --from=build /app/publish .
 
 ENTRYPOINT ["./PKHaX"]


### PR DESCRIPTION
This resolves an issue when trying to run PKHaX where libicu and libssl are required for the app to boot successfully