### PR TITLE
Update to .NET 10, update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 
 WORKDIR /src
 
@@ -10,12 +10,14 @@ COPY . .
 
 RUN dotnet publish "PKHaX.csproj" -c Release -o /app/publish
 
-FROM alpine:3.22
+FROM alpine:3.23.3
 WORKDIR /app
 
 ENV PKHAX_PORT=9000
 ENV PKHAX_PRIVATE_KEY_PATH=/app/private.key
 EXPOSE 9000
+
+RUN apk add --no-cache icu-dev openssl-dev
 
 COPY --from=build /app/publish .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
 
@@ -8,20 +8,14 @@ RUN dotnet restore "PKHaX.csproj"
 
 COPY . .
 
-# This if logic is done to set the correct architecture for the runtime, dotnet publish needs x64 wheras Docker uses amd64
-# TARGETARCH is automatically set by Docker when building the image with the --platform flag
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ] ; then export ARCH="x64" ; else export ARCH=$TARGETARCH ; fi; \
-    dotnet publish "PKHaX.csproj" -c Release -o /app/publish -r "linux-$ARCH"
+RUN dotnet publish "PKHaX.csproj" -c Release
 
-FROM debian:12
+FROM alpine:3.22
 WORKDIR /app
 
 ENV PKHAX_PORT=9000
 ENV PKHAX_PRIVATE_KEY_PATH=/app/private.key
 EXPOSE 9000
-
-RUN apt-get -y update && apt-get install -y libicu-dev libssl-dev
 
 COPY --from=build /app/publish .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet restore "PKHaX.csproj"
 
 COPY . .
 
-RUN dotnet publish "PKHaX.csproj" -c Release
+RUN dotnet publish "PKHaX.csproj" -c Release -o /app/publish
 
 FROM alpine:3.22
 WORKDIR /app

--- a/PKHaX.csproj
+++ b/PKHaX.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dotenv.net" Version="3.1.2" />
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="PKHeX.Core" Version="22.6.1" />
+    <PackageReference Include="dotenv.net" Version="4.0.1" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.5" />
+    <PackageReference Include="PKHeX.Core" Version="26.3.20" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # PKHaX
 ### Legality check server for Pokemon Generation 6
 
-PKHaX makes use of the [PKHeX](https://github.com/kwsch/PKHeX/) project for legality checking
+PKHaX makes use of the [PKHeX](https://github.com/kwsch/PKHeX/) project for Pokémon legality checking.
 
 ## Building
 
-Replace `ubuntu.21.04-x64` with your system
+Run `dotnet publish -c Release`. The binary will be built to `./bin/Release/net10.0/publish/PKHaX`
 
-Binary will be built to `./bin/Release/net6.0/ubuntu.21.04-x64/publish/PKHaX`
-
+Example:
 ```
 git clone https://github.com/PretendoNetwork/PKHaX
 cd PKHaX
-dotnet publish -c Release -r ubuntu.21.04-x64
+dotnet publish -c Release
 ```


### PR DESCRIPTION
Resolves #XXX

### Changes:

Updates the PKHaX project to use .NET 10, remove the OS identifier (so the build path will always be determinant across OSes), remove the CSharp reference as [NU1510](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/nu1510-pruned-references) from Microsoft specifies to do on .NET 10+.

### Testing:

While I was unable to easily connect my console to the test server, I retrieved a validator request I sent to Nintendo Network from a personal capture (`PokemonOR-ConnectInternet-GTS1-READNOTE`), edit the Nintendo size service token to our own, changed the certificate ID to ours, and fire this request off against the local server (test file attached as [validate.req.gz](https://github.com/user-attachments/files/26646430/validate.req.gz), decompress with `gzip -d`).

The following photo was taken by running the existing `master` branch code:
<img width="1750" height="1358" alt="image" src="https://github.com/user-attachments/assets/42e868f2-1bd4-42ad-8563-b03f959ee3fe" />

While this one was tested against my changes:
<img width="1714" height="1370" alt="image" src="https://github.com/user-attachments/assets/ee43a08a-bfef-4b29-af93-dfc0c749110a" />

This will also need some minor updates to ensure the container it runs in is on latest .NET :)

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).

- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.